### PR TITLE
fix bugs in string.h real_dirname()

### DIFF
--- a/src/util/strings.h
+++ b/src/util/strings.h
@@ -79,12 +79,12 @@ std::string real_dirname(const char *filepath){
 		char *p = getcwd(buf, sizeof(buf));
 		if(p != NULL){
 			dir.append(p);
+            dir.append("/");
 		}
 	}
 
 	const char *p = strrchr(filepath, '/');
 	if(p != NULL){
-		dir.append("/");
 		dir.append(filepath, p - filepath);
 	}
 	return dir;


### PR DESCRIPTION
call real_dirname() with parameter "/usr/local/share", it returns "//usr/local"。