### PR TITLE
fix typo

### DIFF
--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -20,7 +20,7 @@ Config* Config::load(const char *filename){
 	FILE *fp = NULL;
 	int lineno = 0;
 
-	if(strcmp(filename, "stdout") == 0){
+	if(strcmp(filename, "stdin") == 0){
 		fp = stdin;
 	}else{
 		fp = fopen(filename, "r");


### PR DESCRIPTION
use stdin as input, not stdout?
BTW, comment in line 55 is obscure: you mean cfg == root is true as first Config, right？
